### PR TITLE
String Index Error Fix 

### DIFF
--- a/model.py
+++ b/model.py
@@ -251,7 +251,6 @@ class Model:
       if bcrypt.checkpw(password.encode('utf-8'), tech[5].encode('utf-8')) and tech[6] == 'Yes':
         self.date = date.today()
         self.setTechName(tech)
-        print(self.tech)
         return True
     return False
   

--- a/model.py
+++ b/model.py
@@ -270,10 +270,10 @@ class Model:
   
   def setTechName(self, tech):
     self.tech = ''
-    if tech[1] != '':
+    if tech[1] != '' and tech[1] is not None:
       self.tech = self.tech + tech[1][0] + '.'
-    if tech[2] != '':
+    if tech[2] != '' and tech[1] is not None:
       self.tech = self.tech + tech[2][0] + '.'
-    if tech[3] != '':
+    if tech[3] != '' and tech[1] is not None:
       self.tech = self.tech + tech[3][0] + '.'
       

--- a/model.py
+++ b/model.py
@@ -250,7 +250,8 @@ class Model:
     for tech in cursor.fetchall():
       if bcrypt.checkpw(password.encode('utf-8'), tech[5].encode('utf-8')) and tech[6] == 'Yes':
         self.date = date.today()
-        self.tech = tech
+        self.setTechName(tech)
+        print(self.tech)
         return True
     return False
   
@@ -267,3 +268,13 @@ class Model:
 
   def fQtDate(self, qtDate):
     return date(qtDate.year(), qtDate.month(), qtDate.day())
+  
+  def setTechName(self, tech):
+    self.tech = ''
+    if tech[1] != '':
+      self.tech = self.tech + tech[1][0] + '.'
+    if tech[2] != '':
+      self.tech = self.tech + tech[2][0] + '.'
+    if tech[3] != '':
+      self.tech = self.tech + tech[3][0] + '.'
+      

--- a/view.py
+++ b/view.py
@@ -628,7 +628,7 @@ class QAReportScreen(QMainWindow):
         dst = self.view.tempify(template)
         document = MailMerge(template)
         document.merge(
-            tech=f"{self.model.tech[1][0]}.{self.model.tech[2][0]}.{self.model.tech[3][0]}."
+            tech=self.model.tech
         )
         document.write(dst)
         context = {
@@ -1294,7 +1294,7 @@ class RejectionLogForm(QMainWindow):
         dst = self.view.tempify(template)
         document = MailMerge(template)
         document.merge(
-            tech=f"{self.model.tech[1][0]}.{self.model.tech[2][0]}.{self.model.tech[3][0]}."
+            tech=self.model.tech
         )
         document.write(dst)
         context = {
@@ -2093,7 +2093,7 @@ class CultureOrderForm(QMainWindow):
                 patientName=f"{self.lName.text()}, {self.fName.text()}",
                 comments=self.cText.toPlainText(),
                 notes=self.nText.toPlainText(),
-                techName=f"{self.model.tech[1][0]}.{self.model.tech[2][0]}.{self.model.tech[3][0]}.",
+                techName=self.model.tech,
             )
             document.write(dst)
             self.view.convertAndPrint(dst)
@@ -2108,7 +2108,7 @@ class CultureOrderForm(QMainWindow):
                 chartID=self.chID.text(),
                 clinicianName=clinician[1] + " " + clinician[0],
                 patientName=f"{self.lName.text()}, {self.fName.text()}",
-                techName=f"{self.model.tech[1][0]}.{self.model.tech[2][0]}.{self.model.tech[3][0]}.",
+                techName=self.model.tech,
             )
             document.write(dst)
             self.view.convertAndPrint(dst)
@@ -3624,7 +3624,7 @@ class CultureResultForm(QMainWindow):
             cultureType=self.sample[8],
             comments=self.cText.toPlainText(),
             directSmear=self.dText.toPlainText(),
-            techName=f"{self.model.tech[1][0]}.{self.model.tech[2][0]}.{self.model.tech[3][0]}.",
+            techName=self.model.tech,
         )
         document.write(dst)
         self.view.convertAndPrint(dst)
@@ -3647,7 +3647,7 @@ class CultureResultForm(QMainWindow):
             comments=self.cText.toPlainText(),
             cultureType=self.sample[8],
             directSmear=self.dText.toPlainText(),
-            techName=f"{self.model.tech[1][0]}.{self.model.tech[2][0]}.{self.model.tech[3][0]}.",
+            techName=self.model.tech,
         )
         document.write(dst)
         context = {
@@ -3678,7 +3678,7 @@ class CultureResultForm(QMainWindow):
             comments=self.cText.toPlainText(),
             cultureType=self.sample[8],
             directSmear=self.dText.toPlainText(),
-            techName=f"{self.model.tech[1][0]}.{self.model.tech[2][0]}.{self.model.tech[3][0]}.",
+            techName=self.model.tech,
         )
         document.write(dst)
         context = {
@@ -4032,7 +4032,7 @@ class CATResultForm(QMainWindow):
             smCount="{:.2e}".format(int(self.strepMutansCount.text())),
             lbCount="{:.2e}".format(int(self.lactobacillusCount.text())),
             reported=self.view.fSlashDate(self.repDate.date()),
-            techName=f"{self.model.tech[1][0]}.{self.model.tech[2][0]}.{self.model.tech[3][0]}.",
+            techName=self.model.tech,
             comments=self.cText.toPlainText(),
         )
         document.write(dst)


### PR DESCRIPTION
This bug fix addresses an edge case where a technician (user) can have a empty string for part of their name (such as no middle name). This affected the printouts from generating. 

This screenshot shows that even without a middle name, users can now still generate printouts and it includes the proper initials. In this case it is E.S. for Eric Simmons.
![image](https://github.com/Kasmanian/COMBDb-oldgen/assets/55244599/c84c5ed7-1bac-4edd-ae54-4c22d625156e)
